### PR TITLE
Add record Proto to reduce branchiness

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -1687,8 +1687,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     /* for readObject() */
     void initBytes(char[] value, int off, int len) {
         if (String.COMPACT_STRINGS) {
-            this.value = StringUTF16.compress(value, off, len);
-            this.coder = (this.value.length == len) ? LATIN1 : UTF16;
+            String.Proto proto = StringUTF16.compress(value, off, len);
+            this.coder = proto.coder();
+            this.value = proto.value();
             return;
         }
         this.coder = UTF16;

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -229,7 +229,22 @@ public final class String
     }
 
     // Proto holder for string field values to pass to String constructor.
-    record Proto(byte[] value, byte coder) {}
+    // Could be "record Proto(byte[] value, byte coder)" but desugared to
+    // ease backporting.
+    static final class Proto {
+        private final byte[] value;
+        private final byte coder;
+        Proto(byte[] value, byte coder) {
+            this.value = value;
+            this.coder = coder;
+        }
+        byte[] value() {
+            return value;
+        }
+        byte coder() {
+            return coder;
+        }
+    }
 
     /**
      * Class String is special cased within the Serialization Stream Protocol.


### PR DESCRIPTION
Adding a simple record `Proto` to hold `byte[] value` and `byte coder` enables the new implementation under 8311906 to avoid some branching. Under the experimentally verified assumption that allocation of such records will be eliminated by JIT this improves performance - in some micros to levels beyond that of the baseline. Numbers on M1 osx-aarch64:

```
Name                                           (size) Cnt   Base   Error    Test   Error  Unit  Change
StringConstructor.newStringFromCharsMixedAll        7  15 19,707 ± 0,332  19,677 ± 0,073 ns/op   1,00x (p = 0,720 )
StringConstructor.newStringFromCharsMixedAll       64  15 26,670 ± 0,313  26,385 ± 0,125 ns/op   1,01x (p = 0,002*)
StringConstructor.newStringFromCharsMixedBegin      7  15  7,733 ± 0,039   7,295 ± 0,042 ns/op   1,06x (p = 0,000*)
StringConstructor.newStringFromCharsMixedBegin     64  15 11,078 ± 0,036  10,841 ± 0,082 ns/op   1,02x (p = 0,000*)
StringConstructor.newStringFromCharsMixedEnd        7  15  9,565 ± 0,049   9,232 ± 0,033 ns/op   1,04x (p = 0,000*)
StringConstructor.newStringFromCharsMixedEnd       64  15 14,617 ± 0,051  14,144 ± 0,025 ns/op   1,03x (p = 0,000*)
StringConstructor.newStringFromCharsMixedSmall      7  15  9,188 ± 0,054   8,911 ± 0,092 ns/op   1,03x (p = 0,000*)
StringConstructor.newStringFromCharsMixedSmall     64  15 13,161 ± 0,064  12,776 ± 0,042 ns/op   1,03x (p = 0,000*)
  * = significant
```

Similar, but less visible, improvements on a linux-x64 workstation: 
```
Name                                           (size) Cnt   Base   Error    Test   Error  Unit  Change
StringConstructor.newStringFromCharsMixedAll        7  15 35.707 ± 0.092  35.743 ± 0.168 ns/op   1.00x (p = 0.436 )
StringConstructor.newStringFromCharsMixedAll       64  15 59.539 ± 0.553  59.390 ± 0.492 ns/op   1.00x (p = 0.414 )
StringConstructor.newStringFromCharsMixedBegin      7  15 13.995 ± 0.028  13.744 ± 0.045 ns/op   1.02x (p = 0.000*)
StringConstructor.newStringFromCharsMixedBegin     64  15 22.699 ± 0.282  22.487 ± 0.359 ns/op   1.01x (p = 0.065 )
StringConstructor.newStringFromCharsMixedEnd        7  15 16.182 ± 0.062  16.100 ± 0.038 ns/op   1.01x (p = 0.000*)
StringConstructor.newStringFromCharsMixedEnd       64  15 27.412 ± 0.259  27.607 ± 0.208 ns/op   0.99x (p = 0.022 )
StringConstructor.newStringFromCharsMixedSmall      7  15 14.844 ± 0.043  14.720 ± 0.039 ns/op   1.01x (p = 0.000*)
StringConstructor.newStringFromCharsMixedSmall     64  15 23.693 ± 0.196  23.677 ± 0.180 ns/op   1.00x (p = 0.800 )
  * = significant
```